### PR TITLE
Make battest.sh more efficient

### DIFF
--- a/battest.sh
+++ b/battest.sh
@@ -1,3 +1,2 @@
 date >> ~/batlog.dat
-/usr/sbin/ioreg -l | grep "CycleCount" >> ~/batlog.dat
-/usr/sbin/ioreg -l | grep "Capacity" >> ~/batlog.dat
+/usr/sbin/ioreg -l | egrep "CycleCount|Capacity" >> ~/batlog.dat


### PR DESCRIPTION
I used egrep to reduce the number of times ioreg is called, which ironically reduces battery usage.
