### PR TITLE
Fix markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ batlog
 ======
 Tracking your Mac's battery useage, with data saved every minute!
 
-As an example, includes 1 Year of my 2012 MacBook Air's. See blog post here: 
+As an example, includes 1 Year of my 2012 MacBook Air's. See blog post here:
 http://www.ifweassume.com/2013/08/the-de-evolution-of-my-laptop-battery.html
 
 Note: The data file is a litle ugly, but nothing a simple parser can't fix.
 
-#Install Guide
+# Install Guide
 
 To run the script yourself, first download the `battest.sh` file. I renamed it using my terminal to be a hidden file like so:
 
@@ -29,7 +29,7 @@ or if you didn't rename it to be hidden, add this line:
 
 However, if you have lots of various cron jobs like me running, you might want to keep a file sitting around with all your cron jobs listed out. I have another hidden file in my home directory called `.cron.username` (replace username, of course) that is full of these cron job lines, like above. You could call this file anything you want, and just use TextEdit to create it if you like. Just create this file with one line in it:
 
-    * * * * * /path/to/your/repo/.battest.sh 
+    * * * * * /path/to/your/repo/.battest.sh
 
 and then tell cron to look at it by typing:
 
@@ -41,7 +41,7 @@ At any time you can see what is in your cron job list by typing:
 
 Happy data gathering!
 
-#Charts
+# Charts
 
 You can turn your data into charts by first converting the batlog data file into a CSV file using [batlog2csv](https://github.com/pietvandongen/batlog2csv) and then dropping the CSV into [batlog chart generator](https://pietvandongen.github.io/batlog-d3-chart/). This will generate charts like:
 


### PR DESCRIPTION
GitHub have updated their markdown implementation: https://githubengineering.com/a-formal-spec-for-github-markdown/

So:

```
#This doesn't work
# This works
```

=>

#This doesn't work
# This works

